### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1129,7 +1129,7 @@ impl Vis {
 		}
 	}
 	/// load the html into elements
-	pub fn load(html: &str) -> Result<Elements, BoxDynError> {
+	pub fn load<'html>(html: impl Into<Cow<'html, str>>) -> Result<Elements<'html>, BoxDynError> {
 		Vis::load_options(html, Vis::options())
 	}
 	/// load the html, and catch the errors


### PR DESCRIPTION
Code isn't tested. The current implementation causes problems in cases like the following:
```rust
async fn fetchDocument(url: &String) -> Result<Elements, String> {
    let client = reqwest::Client::new();
    let res = client.get(url).send().await.unwrap();
    let body = res.text().await.unwrap();

    let doc = Vis::load(&body).unwrap();

    Ok(doc)
}
```
Error:
```
error: cannot return value referencing local variable `body`
```

Something like the proposed changes should solve the problem.