### PR TITLE
fix mismatched_lifetime_syntaxes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ impl INodeTrait for Rc<RefCell<Node>> {
 	}
 
 	/// impl `owner_document`
-	fn owner_document(&self) -> MaybeDoc {
+	fn owner_document(&self) -> MaybeDoc<'_> {
 		if let Some(root) = &self.borrow().root {
 			if let Some(root) = &root.upgrade() {
 				if let Some(doc) = &root.borrow().document {

--- a/src/mesdoc/interface/elements.rs
+++ b/src/mesdoc/interface/elements.rs
@@ -348,7 +348,7 @@ impl<'a> Elements<'a> {
 	///   Ok(())
 	/// }
 	/// ```
-	pub fn document(&self) -> MaybeDoc {
+	pub fn document(&self) -> MaybeDoc<'_> {
 		for ele in self.get_ref() {
 			if let Some(doc) = ele.owner_document() {
 				return Some(doc);

--- a/src/mesdoc/interface/node.rs
+++ b/src/mesdoc/interface/node.rs
@@ -54,7 +54,7 @@ pub trait INodeTrait {
 	fn parent<'b>(&self) -> MaybeElement<'b>;
 
 	// owner document
-	fn owner_document(&self) -> MaybeDoc;
+	fn owner_document(&self) -> MaybeDoc<'_>;
 	// root element
 	fn root_element<'b>(&self) -> Option<BoxDynElement<'b>> {
 		if let Some(doc) = &self.owner_document() {


### PR DESCRIPTION
The lint has added `mismatched_lifetime_syntaxes` checking since Rust 1.89; this PR fixed this warning https://github.com/fefit/visdom/actions/runs/16847653146/job/47729498470.